### PR TITLE
Test cmd matrix

### DIFF
--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -11,3 +11,18 @@ jobs:
   R-package:
     name: R Package Checks
     uses: RMI-PACTA/actions/.github/workflows/R.yml@feat/69-spcify-cmd-check-matrix
+    with:
+      r-cmd-check-matrix: |
+        [
+          {"os": "macOS-latest", "r": "release"},
+          {"os": "windows-latest", "r": "release"},
+          {"os": "windows-latest", "r": "4.1"},
+          {"os": "ubuntu-latest", "r": "release"},
+          {"os": "ubuntu-latest", "r": "devel", "http-user-agent": "release"},
+          {"os": "ubuntu-latest", "r": "oldrel-1"},
+          {"os": "ubuntu-latest", "r": "oldrel-2"},
+          {"os": "ubuntu-latest", "r": "oldrel-3"},
+          {"os": "ubuntu-latest", "r": "oldrel-4"}
+        ]
+
+

--- a/.github/workflows/R.yml
+++ b/.github/workflows/R.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   R-package:
     name: R Package Checks
-    uses: RMI-PACTA/actions/.github/workflows/R.yml@feat/69-spcify-cmd-check-matrix
+    uses: RMI-PACTA/actions/.github/workflows/R.yml@main
     with:
       r-cmd-check-matrix: |
         [

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.multi.loanbook.plot
 Title: Tools to Visualize Climate Metrics for Multiple Loanbooks
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     c(person(given = "Monika",
              family = "Furdyna",


### PR DESCRIPTION
Targets `add-utils` branch (not `main`)

Includes specification of R configs to use for R CMD Check, and a dev version bump, to pass version-check

depends on https://github.com/RMI-PACTA/actions/pull/70