### PR TITLE
Adjust to variable result grouping

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pacta.multi.loanbook.plot
 Title: Tools to Visualize Climate Metrics for Multiple Loanbooks
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: 
     c(person(given = "Monika",
              family = "Furdyna",

--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -23,6 +23,19 @@ plot_sankey <- function(data,
                         save_png_to = NULL,
                         png_name = "sankey.png",
                         nodes_order_from_data = FALSE) {
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
+    }
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
+    }
+  } else {
+    data <- data %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
+  }
+
   check_plot_sankey(
     data = data,
     by_group = by_group,

--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -1,7 +1,9 @@
 #' Make a sankey plot
 #'
 #' @param data data.frame. Should have the same format as output of
-#'   `prep_sankey()`
+#'   `prep_sankey()` and contain columns: `"middle_node"`, optionally
+#'   `"middle_node2"`, `"is_aligned"`, `"loan_size_outstanding"`, and any column
+#'   implied by `by_group`.
 #' @param by_group Character. Vector of length 1. Variable to group by.
 #' @param capitalise_node_labels Logical. Flag indicating if node labels should
 #'   be converted into better looking capitalised form.

--- a/R/plot_sankey.R
+++ b/R/plot_sankey.R
@@ -3,8 +3,8 @@
 #' @param data data.frame. Should have the same format as output of
 #'   `prep_sankey()` and contain columns: `"middle_node"`, optionally
 #'   `"middle_node2"`, `"is_aligned"`, `"loan_size_outstanding"`, and any column
-#'   implied by `by_group`.
-#' @param by_group Character. Vector of length 1. Variable to group by.
+#'   implied by `group_var`.
+#' @param group_var Character. Vector of length 1. Variable to group by.
 #' @param capitalise_node_labels Logical. Flag indicating if node labels should
 #'   be converted into better looking capitalised form.
 #' @param save_png_to Character. Path where the output in png format should be
@@ -20,34 +20,34 @@
 #' @examples
 #' # TODO
 plot_sankey <- function(data,
-                        by_group,
+                        group_var,
                         capitalise_node_labels = TRUE,
                         save_png_to = NULL,
                         png_name = "sankey.png",
                         nodes_order_from_data = FALSE) {
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
   check_plot_sankey(
     data = data,
-    by_group = by_group,
+    group_var = group_var,
     capitalise_node_labels = capitalise_node_labels
   )
 
   if (capitalise_node_labels) {
     data_links <- data %>%
       dplyr::mutate(
-        by_group = r2dii.plot::to_title(!!rlang::sym(by_group)),
+        group_var = r2dii.plot::to_title(!!rlang::sym(group_var)),
         middle_node = r2dii.plot::to_title(.data$middle_node)
       )
     if ("middle_node2" %in% names(data_links)) {
@@ -62,7 +62,7 @@ plot_sankey <- function(data,
 
   links_1 <- data_links %>%
     dplyr::select(
-      source = .env$by_group,
+      source = .env$group_var,
       target = "middle_node",
       value = "loan_size_outstanding",
       group = "is_aligned"
@@ -71,7 +71,7 @@ plot_sankey <- function(data,
   if ("middle_node2" %in% names(data_links)) {
     links_2 <- data_links %>%
       dplyr::select(
-        .env$by_group,
+        .env$group_var,
         source = "middle_node",
         target = "middle_node2",
         value = "loan_size_outstanding",
@@ -80,7 +80,7 @@ plot_sankey <- function(data,
 
     links_3 <- data_links %>%
       dplyr::select(
-        .env$by_group,
+        .env$group_var,
         source = "middle_node2",
         target = "is_aligned",
         value = "loan_size_outstanding",
@@ -91,7 +91,7 @@ plot_sankey <- function(data,
   } else {
     links_2 <- data_links %>%
       dplyr::select(
-        .env$by_group,
+        .env$group_var,
         source = "middle_node",
         target = "is_aligned",
         value = "loan_size_outstanding",
@@ -167,9 +167,9 @@ plot_sankey <- function(data,
 }
 
 check_plot_sankey <- function(data,
-                              by_group,
+                              group_var,
                               capitalise_node_labels) {
-  crucial_names <- c(by_group, "middle_node", "is_aligned", "loan_size_outstanding")
+  crucial_names <- c(group_var, "middle_node", "is_aligned", "loan_size_outstanding")
   abort_if_missing_names(data, crucial_names)
   if (!is.logical(capitalise_node_labels)) {
     rlang::abort(

--- a/R/plot_scatter.R
+++ b/R/plot_scatter.R
@@ -13,7 +13,7 @@
 #' @param alignment_limit Numeric. Limit to be applied to the x- and y-axis
 #'   scales and to alignment values for colouring. By default the maximum
 #'   absolute alignment value of is used.
-#' @param data_level Character. Level of the plotted data. Can be 'bank' or
+#' @param data_level Character. Level of the plotted data. Can be 'group_var' or
 #'   'company'.
 #' @param cap_outliers Numeric. Cap which should be applied to the alignment
 #'   values in the data. Values bigger than cap are plotted on the border of the
@@ -37,7 +37,7 @@ plot_scatter <- function(data,
                          title = NULL,
                          subtitle = NULL,
                          alignment_limit = NULL,
-                         data_level = c("company", "bank"),
+                         data_level = c("company", "group_var"),
                          cap_outliers = NULL,
                          floor_outliers = NULL) {
   rlang::arg_match(data_level)
@@ -74,9 +74,9 @@ plot_scatter <- function(data,
       subtitle <- "Each dot is a company. The companies in the top right quadrant are both building out\n low-carbon technologies and phasing out high-carbon technologies at rates\ngreater or equal to those required by the scenario."
     }
   } else {
-    title <- paste0(title, " per Bank")
+    title <- paste0(title, " by group")
     if (is.null(subtitle)) {
-      subtitle <- "Each dot is a bank. The banks in the top right quadrant are exposed to companies\nwhich on aggregate level are both building out low-carbon technologies and phasing out\nhigh-carbon technologies at rates greater or equal to those required by the scenario."
+      subtitle <- paste0("Each dot is a group. The groups in the top right quadrant are exposed to companies\nwhich on aggregate level are both building out low-carbon technologies and phasing out\nhigh-carbon technologies at rates greater or equal to those required by the scenario.")
     }
   }
 
@@ -186,7 +186,7 @@ plot_scatter <- function(data,
     ) +
     ggplot2::scale_shape_manual(
       name = "",
-      values = c("bank" = 16, "benchmark" = 21, "company" = 16, "other" = 16),
+      values = c("group" = 16, "benchmark" = 21, "company" = 16, "other" = 16),
       labels = r2dii.plot::to_title
     ) +
     r2dii.plot::theme_2dii() +

--- a/R/plot_scatter_alignment_exposure.R
+++ b/R/plot_scatter_alignment_exposure.R
@@ -9,9 +9,7 @@
 #'   values in the data. Values bigger than cap are plotted on the border of the
 #'   plot.
 #' @param category Character. Character specifying the variable that contains
-#'   the groups by which to analyse the loan books. Usually this will be
-#'   `"group_id"` unless there is a clearly specified reason to use another
-#'   category.
+#'   the groups by which to analyse the loan books.
 #' @param currency Character. Currency to display in the plot labels.
 #'
 #' @return object of type "ggplot"

--- a/R/plot_scatter_alignment_exposure.R
+++ b/R/plot_scatter_alignment_exposure.R
@@ -2,14 +2,14 @@
 #'
 #' @param data data.frame. Should have the same format as output of
 #'   `prep_scatter()` and contain columns: `'name'`, `'buildout'`, `'phaseout'`,
-#'   `'net'`, and any column implied by `by_group`.
+#'   `'net'`, and any column implied by `group_var`.
 #' @param floor_outliers Numeric. Floor which should be applied to the alignment
 #'   values in the data. Values smaller than floor are plotted on the border of
 #'   the plot.
 #' @param cap_outliers Numeric. Cap which should be applied to the alignment
 #'   values in the data. Values bigger than cap are plotted on the border of the
 #'   plot.
-#' @param by_group Character. Character specifying the variable that contains
+#' @param group_var Character. Character specifying the variable that contains
 #'   the groups by which to analyse the loan books.
 #' @param currency Character. Currency to display in the plot labels.
 #'
@@ -21,19 +21,19 @@
 plot_scatter_alignment_exposure <- function(data,
                                             floor_outliers,
                                             cap_outliers,
-                                            by_group,
+                                            group_var,
                                             currency) {
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
   if (!is.null(floor_outliers)) {
@@ -73,7 +73,7 @@ plot_scatter_alignment_exposure <- function(data,
       ggplot2::aes(
         x = .data$sum_loan_size_outstanding,
         y = .data$exposure_weighted_net_alignment,
-        color = !!rlang::sym(by_group)
+        color = !!rlang::sym(group_var)
       )
     ) +
     ggplot2::geom_point() +
@@ -86,7 +86,7 @@ plot_scatter_alignment_exposure <- function(data,
     ggplot2::labs(
       title = title,
       subtitle = subtitle,
-      color = r2dii.plot::to_title(by_group)
+      color = r2dii.plot::to_title(group_var)
     ) +
     ggplot2::xlab(glue::glue("Financial Exposure (in {currency})")) +
     ggplot2::ylab("Net Aggregate Alignment") +

--- a/R/plot_scatter_alignment_exposure.R
+++ b/R/plot_scatter_alignment_exposure.R
@@ -8,7 +8,7 @@
 #' @param cap_outliers Numeric. Cap which should be applied to the alignment
 #'   values in the data. Values bigger than cap are plotted on the border of the
 #'   plot.
-#' @param category Character. Character specifying the variable that contains
+#' @param by_group Character. Character specifying the variable that contains
 #'   the groups by which to analyse the loan books.
 #' @param currency Character. Currency to display in the plot labels.
 #'
@@ -20,19 +20,19 @@
 plot_scatter_alignment_exposure <- function(data,
                                             floor_outliers,
                                             cap_outliers,
-                                            category,
+                                            by_group,
                                             currency) {
-  if (!is.null(category)) {
-    if (!inherits(category, "character")) {
-      stop("category must be of class character")
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
     }
-    if (!length(category) == 1) {
-      stop("category must be of length 1")
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    category <- "aggregate_loan_book"
+    by_group <- "aggregate_loan_book"
   }
 
   if (!is.null(floor_outliers)) {
@@ -72,7 +72,7 @@ plot_scatter_alignment_exposure <- function(data,
       ggplot2::aes(
         x = .data$sum_loan_size_outstanding,
         y = .data$exposure_weighted_net_alignment,
-        color = !!rlang::sym(category)
+        color = !!rlang::sym(by_group)
       )
     ) +
     ggplot2::geom_point() +
@@ -85,7 +85,7 @@ plot_scatter_alignment_exposure <- function(data,
     ggplot2::labs(
       title = title,
       subtitle = subtitle,
-      color = r2dii.plot::to_title(category)
+      color = r2dii.plot::to_title(by_group)
     ) +
     ggplot2::xlab(glue::glue("Financial Exposure (in {currency})")) +
     ggplot2::ylab("Net Aggregate Alignment") +

--- a/R/plot_scatter_alignment_exposure.R
+++ b/R/plot_scatter_alignment_exposure.R
@@ -22,6 +22,19 @@ plot_scatter_alignment_exposure <- function(data,
                                             cap_outliers,
                                             category,
                                             currency) {
+  if (!is.null(category)) {
+    if (!inherits(category, "character")) {
+      stop("category must be of class character")
+    }
+    if (!length(category) == 1) {
+      stop("category must be of length 1")
+    }
+  } else {
+    data <- data %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    category <- "aggregate_loan_book"
+  }
+
   if (!is.null(floor_outliers)) {
     data <- data %>%
       dplyr::mutate(

--- a/R/plot_scatter_alignment_exposure.R
+++ b/R/plot_scatter_alignment_exposure.R
@@ -1,7 +1,8 @@
 #' Plot alignment scatterplot
 #'
 #' @param data data.frame. Should have the same format as output of
-#'   `prep_scatter()` and contain columns: 'name', 'buildout', phaseout', 'net'.
+#'   `prep_scatter()` and contain columns: `'name'`, `'buildout'`, `'phaseout'`,
+#'   `'net'`, and any column implied by `by_group`.
 #' @param floor_outliers Numeric. Floor which should be applied to the alignment
 #'   values in the data. Values smaller than floor are plotted on the border of
 #'   the plot.

--- a/R/plot_scatter_animated.R
+++ b/R/plot_scatter_animated.R
@@ -3,7 +3,7 @@
 #' @param data data.frame. Should have the same format as output of
 #'   `prep_scatter_animated()` and contain columns: 'name', 'buildout',
 #'   'phaseout', 'net' and 'year'.
-#' @param data_level Character. Level of the plotted data. Can be 'bank' or
+#' @param data_level Character. Level of the plotted data. Can be 'group_var' or
 #'   'company'.
 #' @param sector Character. Sector name to be used in the plot title.
 #' @param scenario_source Character. Scenario source to be used in the plot
@@ -29,7 +29,7 @@
 #' # TODO
 # nolint start: cyclocomp_linter.
 plot_scatter_animated <- function(data,
-                                  data_level = c("company", "bank"),
+                                  data_level = c("company", "group_var"),
                                   sector = NULL,
                                   scenario_source = NULL,
                                   scenario = NULL,
@@ -70,9 +70,9 @@ plot_scatter_animated <- function(data,
       subtitle <- "Each dot is a company. The companies in the top right quadrant are both building out\n low-carbon technologies and phasing out high-carbon technologies at rates\ngreater or equal to those required by the scenario."
     }
   } else {
-    title <- paste0(title, " per Bank")
+    title <- paste0(title, " per group")
     if (is.null(subtitle)) {
-      subtitle <- "Each dot is a bank. The banks in the top right quadrant are exposed to companies\nwhich on aggregate level are both building out low-carbon technologies and phasing out\nhigh-carbon technologies at rates greater or equal to those required by the scenario."
+      subtitle <- paste0("Each dot is a group. The groups in the top right quadrant are exposed to companies\nwhich on aggregate level are both building out low-carbon technologies and phasing out\nhigh-carbon technologies at rates greater or equal to those required by the scenario.")
     }
   }
 

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -1,8 +1,8 @@
 #' Plot alignment timeline
 #'
 #' @param data data.frame Should have the same format as output of
-#'   `prep_timeline()` and contain columns: 'direction', 'year',
-#'   'exposure_weighted_net_alignment', by_group.
+#'   `prep_timeline()` and contain columns: `'direction'`, `'year'`,
+#'   `'exposure_weighted_net_alignment'`, and any column implied by `by_group`.
 #' @param sector Character. Sector name to be used in the plot title.
 #' @param scenario_source Character. Scenario source to be used in the plot
 #'   caption.

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -20,6 +20,7 @@
 #'
 #' @examples
 #' # TODO
+# nolint start: cyclocomp_linter.
 plot_timeline <- function(data,
                           sector = NULL,
                           scenario_source = NULL,
@@ -120,6 +121,7 @@ plot_timeline <- function(data,
     )
   p
 }
+# nolint end
 
 check_timeline <- function(data, alignment_limits, by_group) {
   abort_if_missing_names(

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -65,6 +65,19 @@ plot_timeline <- function(data,
     alignment_limits <- c(-max_value, max_value)
   }
 
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
+    }
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
+    }
+  } else {
+    data <- data %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
+  }
+
   check_timeline(data, alignment_limits, by_group)
 
   p <- ggplot2::ggplot(

--- a/R/plot_timeline.R
+++ b/R/plot_timeline.R
@@ -2,13 +2,13 @@
 #'
 #' @param data data.frame Should have the same format as output of
 #'   `prep_timeline()` and contain columns: `'direction'`, `'year'`,
-#'   `'exposure_weighted_net_alignment'`, and any column implied by `by_group`.
+#'   `'exposure_weighted_net_alignment'`, and any column implied by `group_var`.
 #' @param sector Character. Sector name to be used in the plot title.
 #' @param scenario_source Character. Scenario source to be used in the plot
 #'   caption.
 #' @param scenario Character. Scenario name to be used in the plot caption.
 #' @param region Character. Region to be used in the plot caption.
-#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param group_var Character. Vector of length 1. Variable to group by.
 #' @param title Character. Custom title if different than default.
 #' @param subtitle Character. Custom subtitle if different than default.
 #' @param alignment_limits Numeric vector of size 2. Limits to be applied to
@@ -26,7 +26,7 @@ plot_timeline <- function(data,
                           scenario_source = NULL,
                           scenario = NULL,
                           region = NULL,
-                          by_group = NULL,
+                          group_var = NULL,
                           title = NULL,
                           subtitle = NULL,
                           alignment_limits = NULL) {
@@ -66,20 +66,20 @@ plot_timeline <- function(data,
     alignment_limits <- c(-max_value, max_value)
   }
 
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
-  check_timeline(data, alignment_limits, by_group)
+  check_timeline(data, alignment_limits, group_var)
 
   p <- ggplot2::ggplot(
     data,
@@ -106,7 +106,7 @@ plot_timeline <- function(data,
       labels = scales::percent
     ) +
     ggplot2::facet_grid(
-      rows = ggplot2::vars(!!rlang::sym(by_group)),
+      rows = ggplot2::vars(!!rlang::sym(group_var)),
       cols = ggplot2::vars(.data$direction),
       labeller = ggplot2::as_labeller(format_facet_labels)
     ) +
@@ -123,14 +123,14 @@ plot_timeline <- function(data,
 }
 # nolint end
 
-check_timeline <- function(data, alignment_limits, by_group) {
+check_timeline <- function(data, alignment_limits, group_var) {
   abort_if_missing_names(
     data,
     c(
       "direction",
       "year",
       "exposure_weighted_net_alignment",
-      by_group
+      group_var
     )
   )
   if ((length(alignment_limits) != 2) || (!is.numeric(alignment_limits))) {

--- a/R/prep_sankey.R
+++ b/R/prep_sankey.R
@@ -1,8 +1,8 @@
 #' Prepare data to plot using `plot_sankey()`
 #'
 #' @param data_alignment data.frame. Holds aggregated alignment metrics per
-#'   company for tms sectors. Must contain columns: `by_group`, `name_abcd`,
-#'   `sector`.
+#'   company for tms sectors. Must contain columns: `"name_abcd"`,
+#'   `"sector"` and any column implied by `by_group`.
 #' @param region Character. Region to filter `data_alignment` data frame on.
 #' @param year Integer. Year on which `data_alignment` should be filtered.
 #' @param by_group Character. Vector of length 1. Variable to group by.

--- a/R/prep_sankey.R
+++ b/R/prep_sankey.R
@@ -2,10 +2,10 @@
 #'
 #' @param data_alignment data.frame. Holds aggregated alignment metrics per
 #'   company for tms sectors. Must contain columns: `"name_abcd"`,
-#'   `"sector"` and any column implied by `by_group`.
+#'   `"sector"` and any column implied by `group_var`.
 #' @param region Character. Region to filter `data_alignment` data frame on.
 #' @param year Integer. Year on which `data_alignment` should be filtered.
-#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param group_var Character. Vector of length 1. Variable to group by.
 #' @param middle_node Character. Column specifying the middle nodes to be
 #'   plotted in sankey plot. Must be present in `data_alignment`.
 #' @param middle_node2 Character. Column specifying the middle nodes to be
@@ -19,27 +19,27 @@
 prep_sankey <- function(data_alignment,
                         region,
                         year,
-                        by_group,
+                        group_var,
                         middle_node,
                         middle_node2 = NULL) {
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data_alignment <- data_alignment %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
   check_prep_sankey(
     data_alignment = data_alignment,
     region = region,
     year = year,
-    by_group = by_group,
+    group_var = group_var,
     middle_node = middle_node,
     middle_node2 = middle_node2
   )
@@ -60,11 +60,11 @@ prep_sankey <- function(data_alignment,
         ),
         middle_node = !!rlang::sym(middle_node)
       ) %>%
-      dplyr::select(by_group, "middle_node", "is_aligned", "loan_size_outstanding") %>%
-      dplyr::group_by(!!rlang::sym(by_group), .data$middle_node, .data$is_aligned) %>%
+      dplyr::select(group_var, "middle_node", "is_aligned", "loan_size_outstanding") %>%
+      dplyr::group_by(!!rlang::sym(group_var), .data$middle_node, .data$is_aligned) %>%
       dplyr::summarise(loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE)) %>%
       dplyr::ungroup() %>%
-      dplyr::arrange(!!rlang::sym(by_group), .data$is_aligned)
+      dplyr::arrange(!!rlang::sym(group_var), .data$is_aligned)
   } else {
     data_out <- data_alignment %>%
       dplyr::mutate(
@@ -76,11 +76,11 @@ prep_sankey <- function(data_alignment,
         middle_node = !!rlang::sym(middle_node),
         middle_node2 = !!rlang::sym(middle_node2)
       ) %>%
-      dplyr::select(by_group, "middle_node", "middle_node2", "is_aligned", "loan_size_outstanding") %>%
-      dplyr::group_by(!!rlang::sym(by_group), .data$middle_node, .data$middle_node2, .data$is_aligned) %>%
+      dplyr::select(group_var, "middle_node", "middle_node2", "is_aligned", "loan_size_outstanding") %>%
+      dplyr::group_by(!!rlang::sym(group_var), .data$middle_node, .data$middle_node2, .data$is_aligned) %>%
       dplyr::summarise(loan_size_outstanding = sum(.data$loan_size_outstanding, na.rm = TRUE)) %>%
       dplyr::ungroup() %>%
-      dplyr::arrange(!!rlang::sym(by_group), .data$is_aligned)
+      dplyr::arrange(!!rlang::sym(group_var), .data$is_aligned)
   }
   data_out
 }
@@ -88,10 +88,10 @@ prep_sankey <- function(data_alignment,
 check_prep_sankey <- function(data_alignment,
                               region,
                               year,
-                              by_group,
+                              group_var,
                               middle_node,
                               middle_node2) {
-  names_all <- c(by_group, "name_abcd", "sector")
+  names_all <- c(group_var, "name_abcd", "sector")
   names_aggergate <- c("region", "year")
   abort_if_missing_names(data_alignment, c(names_all, names_aggergate))
   if (!(region %in% unique(data_alignment$region))) {

--- a/R/prep_sankey.R
+++ b/R/prep_sankey.R
@@ -29,6 +29,10 @@ prep_sankey <- function(data_alignment,
     if (!length(by_group) == 1) {
       stop("by_group must be of length 1")
     }
+  } else {
+    data_alignment <- data_alignment %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
   }
 
   check_prep_sankey(

--- a/R/prep_sankey.R
+++ b/R/prep_sankey.R
@@ -3,8 +3,6 @@
 #' @param data_alignment data.frame. Holds aggregated alignment metrics per
 #'   company for tms sectors. Must contain columns: `group_id`, `name_abcd`,
 #'   `sector`.
-#' @param matched_loanbook data.frame. Holds the matched loan books of a set of
-#'   groups. Must include a column `group_id` and `loan_size_outstanding`.
 #' @param region Character. Region to filter `data_alignment` data frame on.
 #' @param year Integer. Year on which `data_alignment` should be filtered.
 #' @param middle_node Character. Column specifying the middle nodes to be
@@ -18,14 +16,12 @@
 #' @examples
 #' # TODO
 prep_sankey <- function(data_alignment,
-                        matched_loanbook,
                         region,
                         year,
                         middle_node,
                         middle_node2 = NULL) {
   check_prep_sankey(
     data_alignment,
-    matched_loanbook,
     region,
     year,
     middle_node,
@@ -38,12 +34,8 @@ prep_sankey <- function(data_alignment,
       .data$year == .env$year
     )
 
-  matched_loanbook <- matched_loanbook %>%
-    dplyr::select("group_id", "name_abcd", "sector", "loan_size_outstanding")
-
   if (is.null(middle_node2)) {
     data_out <- data_alignment %>%
-      dplyr::inner_join(matched_loanbook, by = c("group_id", "name_abcd", "sector")) %>%
       dplyr::mutate(
         is_aligned = dplyr::case_when(
           alignment_metric >= 0 ~ "Aligned",
@@ -59,7 +51,6 @@ prep_sankey <- function(data_alignment,
       dplyr::arrange(.data$group_id, .data$is_aligned)
   } else {
     data_out <- data_alignment %>%
-      dplyr::inner_join(matched_loanbook, by = c("group_id", "name_abcd", "sector")) %>%
       dplyr::mutate(
         is_aligned = dplyr::case_when(
           alignment_metric >= 0 ~ "Aligned",
@@ -79,7 +70,6 @@ prep_sankey <- function(data_alignment,
 }
 
 check_prep_sankey <- function(data_alignment,
-                              matched_loanbook,
                               region,
                               year,
                               middle_node,
@@ -87,7 +77,6 @@ check_prep_sankey <- function(data_alignment,
   names_all <- c("group_id", "name_abcd", "sector")
   names_aggergate <- c("region", "year")
   abort_if_missing_names(data_alignment, c(names_all, names_aggergate))
-  abort_if_missing_names(matched_loanbook, c(names_all, "loan_size_outstanding"))
   if (!(region %in% unique(data_alignment$region))) {
     rlang::abort(c(
       "`region_tms` value not found in `data_alignment` dataset.",

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -8,8 +8,8 @@
 #'   contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
 #'   `'exposure_weighted_net_alignment'`.
-#' @param data_level Character. Level of the plotted data. Can be 'bank' or
-#'   'company'.
+#' @param data_level Character. Level of the plotted data. Can be `'bank'` or
+#'   `'company'`.
 #' @param year Integer. Year on which the data should be filtered.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
@@ -83,7 +83,14 @@ prep_scatter <- function(data_bopo,
   data_scatter
 }
 
-check_prep_scatter <- function(data, year, sector, region, by_group, groups_to_plot, name_col, value_col) {
+check_prep_scatter <- function(data,
+                               year,
+                               sector,
+                               region,
+                               by_group,
+                               groups_to_plot,
+                               name_col,
+                               value_col) {
   abort_if_missing_names(
     data,
     c(

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -8,7 +8,7 @@
 #'   contain columns: `group_var`, `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
 #'   `'exposure_weighted_net_alignment'`.
-#' @param data_level Character. Level of the plotted data. Can be `'bank'` or
+#' @param data_level Character. Level of the plotted data. Can be `'group_var'` or
 #'   `'company'`.
 #' @param year Integer. Year on which the data should be filtered.
 #' @param sector Character. Sector to filter data on.
@@ -23,7 +23,7 @@
 #' # TODO
 prep_scatter <- function(data_bopo,
                          data_net,
-                         data_level = c("bank", "company"),
+                         data_level = c("group_var", "company"),
                          year,
                          sector,
                          region,
@@ -46,7 +46,7 @@ prep_scatter <- function(data_bopo,
     group_var <- "aggregate_loan_book"
   }
 
-  if (data_level == "bank") {
+  if (data_level == "group_var") {
     name_col <- group_var
     value_col <- "exposure_weighted_net_alignment"
   } else {
@@ -80,7 +80,7 @@ prep_scatter <- function(data_bopo,
     dplyr::mutate(
       datapoint = dplyr::case_when(
         grepl(".*[Bb]enchmark,*", .data$name) ~ "benchmark",
-        TRUE & (data_level == "bank") ~ "bank",
+        TRUE & (data_level == "group_var") ~ "group",
         TRUE & (data_level == "company") ~ "company",
         TRUE ~ "other"
       )

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -14,7 +14,7 @@
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
 #' @param by_group Character. Vector of length 1. Variable to group by.
-#' @param groups_to_plot Character vector. Bank ids to filter on.
+#' @param groups_to_plot Character vector. Groups to filter on.
 #'
 #' @return data.frame
 #' @export

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -38,6 +38,12 @@ prep_scatter <- function(data_bopo,
     if (!length(by_group) == 1) {
       stop("by_group must be of length 1")
     }
+  } else {
+    data_bopo <- data_bopo %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    data_net <- data_net %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
   }
 
   if (data_level == "bank") {

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -1,19 +1,20 @@
 #' Prepare data to plot scatterplot
 #'
 #' @param data_bopo data.frame. Data containing buildout and phaseout alignment
-#'   values. Must contain columns: 'group_id', 'year', 'sector', 'region',
-#'   'direction' and either 'name_abcd' and 'alignment_metric' or
-#'   'exposure_weighted_net_alignment'.
+#'   values. Must contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
+#'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
+#'   `'exposure_weighted_net_alignment'`.
 #' @param data_net data.frame. Data containing net alignment values. Must
-#'   contain columns: 'group_id', 'year', 'sector', 'region', 'direction' and
-#'   either 'name_abcd' and 'alignment_metric' or
-#'   'exposure_weighted_net_alignment'.
+#'   contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
+#'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
+#'   `'exposure_weighted_net_alignment'`.
 #' @param data_level Character. Level of the plotted data. Can be 'bank' or
 #'   'company'.
 #' @param year Integer. Year on which the data should be filtered.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
-#' @param group_ids_to_plot Character vector. Bank ids to filter on.
+#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param groups_to_plot Character vector. Bank ids to filter on.
 #'
 #' @return data.frame
 #' @export
@@ -26,22 +27,37 @@ prep_scatter <- function(data_bopo,
                          year,
                          sector,
                          region,
-                         group_ids_to_plot = NULL) {
+                         by_group,
+                         groups_to_plot = NULL) {
   rlang::arg_match(data_level)
 
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
+    }
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
+    }
+  }
+
   if (data_level == "bank") {
-    name_col <- "group_id"
+    name_col <- by_group
     value_col <- "exposure_weighted_net_alignment"
   } else {
     name_col <- "name_abcd"
     value_col <- "alignment_metric"
   }
 
-  check_prep_scatter(data_bopo, year, sector, region, group_ids_to_plot, name_col, value_col)
-  check_prep_scatter(data_net, year, sector, region, group_ids_to_plot, name_col, value_col)
+  check_prep_scatter(data_bopo, year, sector, region, by_group, groups_to_plot, name_col, value_col)
+  check_prep_scatter(data_net, year, sector, region, by_group, groups_to_plot, name_col, value_col)
 
-  if (is.null(group_ids_to_plot)) {
-    group_ids_to_plot <- unique(c(data_bopo$group_id, data_net$group_id))
+  if (is.null(groups_to_plot)) {
+    groups_to_plot <- unique(
+      c(
+        dplyr::pull(data_bopo, by_group),
+        dplyr::pull(data_net, by_group)
+      )
+    )
   }
 
   data_scatter <- data_bopo %>%
@@ -50,7 +66,7 @@ prep_scatter <- function(data_bopo,
       .data$year == .env$year,
       .data$sector == .env$sector,
       .data$region == .env$region,
-      .data$group_id %in% group_ids_to_plot
+      !!rlang::sym(by_group) %in% groups_to_plot
     ) %>%
     dplyr::select("name" = name_col, "direction", "value" = value_col) %>%
     dplyr::distinct() %>%
@@ -67,13 +83,21 @@ prep_scatter <- function(data_bopo,
   data_scatter
 }
 
-check_prep_scatter <- function(data, year, sector, region, group_ids_to_plot, name_col, value_col) {
-  abort_if_missing_names(data, c(
-    "group_id", "year",
-    "sector", "region", "direction", name_col, value_col
-  ))
+check_prep_scatter <- function(data, year, sector, region, by_group, groups_to_plot, name_col, value_col) {
+  abort_if_missing_names(
+    data,
+    c(
+      by_group,
+      "year",
+      "sector",
+      "region",
+      "direction",
+      name_col,
+      value_col
+    )
+  )
   abort_if_unknown_values(sector, data, "sector")
   abort_if_unknown_values(region, data, "region")
   abort_if_unknown_values(year, data, "year")
-  abort_if_unknown_values(group_ids_to_plot, data, "group_id")
+  abort_if_unknown_values(groups_to_plot, data, by_group)
 }

--- a/R/prep_scatter.R
+++ b/R/prep_scatter.R
@@ -1,9 +1,9 @@
 #' Prepare data to plot scatterplot
 #'
 #' @param data_bopo data.frame. Data containing buildout and phaseout alignment
-#'   values. Must contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
+#'   values. Must contain columns: `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
-#'   `'exposure_weighted_net_alignment'`.
+#'   `'exposure_weighted_net_alignment'` plus any column implied by `by_group`.
 #' @param data_net data.frame. Data containing net alignment values. Must
 #'   contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or

--- a/R/prep_scatter_alignment_exposure.R
+++ b/R/prep_scatter_alignment_exposure.R
@@ -3,14 +3,14 @@
 #' @param data data.frame. Holds net aggregated alignment metrics on the loan
 #'   book level. Must contain columns: `"scenario"`, `"region"`,
 #'   `"sector"`, `"year"`, `"exposure_weighted_net_alignment"`,
-#'   `"sum_loan_size_outstanding"` and any column implied by `by_group`.
+#'   `"sum_loan_size_outstanding"` and any column implied by `group_var`.
 #' @param year Integer. Year on which `data` should be filtered.
 #' @param region Character. Region to filter `data` data frame on.
 #' @param scenario Character. Scenario to filter `data` data frame on.
-#' @param by_group Character. Vector of length 1. A column to group by. Must be
+#' @param group_var Character. Vector of length 1. A column to group by. Must be
 #'   available variables in `data`.
 #' @param exclude_groups Character. Character specifying any values from
-#'   `by_group` that should not be included in the analysis. This is useful to
+#'   `group_var` that should not be included in the analysis. This is useful to
 #'   remove benchmarks that are not meant to be compared at the same level.
 #'   Defaults to `"benchmark"`.
 #'
@@ -23,24 +23,24 @@ prep_scatter_alignment_exposure <- function(data,
                                             year,
                                             region,
                                             scenario,
-                                            by_group,
+                                            group_var,
                                             exclude_groups = "benchmark") {
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
   data <- data %>%
     dplyr::filter(
-      !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(by_group))
+      !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(group_var))
     ) %>%
     dplyr::filter(
       .data$year == .env$year,
@@ -50,7 +50,7 @@ prep_scatter_alignment_exposure <- function(data,
     dplyr::select(
       dplyr::all_of(
         c(
-          by_group,
+          group_var,
           "scenario",
           "region",
           "sector",

--- a/R/prep_scatter_alignment_exposure.R
+++ b/R/prep_scatter_alignment_exposure.R
@@ -3,7 +3,7 @@
 #' @param data data.frame. Holds net aggregated alignment metrics on the loan
 #'   book level. Must contain columns: `"scenario"`, `"region"`,
 #'   `"sector"`, `"year"`, `"exposure_weighted_net_alignment"`,
-#'   `"sum_loan_size_outstanding"` and any column implied by `by_group`
+#'   `"sum_loan_size_outstanding"` and any column implied by `by_group`.
 #' @param year Integer. Year on which `data` should be filtered.
 #' @param region Character. Region to filter `data` data frame on.
 #' @param scenario Character. Scenario to filter `data` data frame on.

--- a/R/prep_scatter_alignment_exposure.R
+++ b/R/prep_scatter_alignment_exposure.R
@@ -1,17 +1,15 @@
 #' Prepare data to plot using `plot_scatter_alignment_exposure()`
 #'
 #' @param data data.frame. Holds net aggregated alignment metrics on the loan
-#'   book level. Must contain columns: `group_id`, `scenario`, `region`,
-#'   `sector`, `year`, `exposure_weighted_net_alignment`,
-#'   `sum_loan_size_outstanding`.
+#'   book level. Must contain columns: `"scenario"`, `"region"`,
+#'   `"sector"`, `"year"`, `"exposure_weighted_net_alignment"`,
+#'   `"sum_loan_size_outstanding"` and any column implied by `category`
 #' @param year Integer. Year on which `data` should be filtered.
 #' @param region Character. Region to filter `data` data frame on.
 #' @param scenario Character. Scenario to filter `data` data frame on.
-#' @param category Character. Character specifying the variable that contains
-#'   the groups by which to analyse the loan books. Usually this will be
-#'   `"group_id"` unless there is a clearly specified reason to use another
-#'   category.
-#' @param exclude_group_ids Character. Character specifying any values from
+#' @param category Character. Vector of length 1. A column to group by. Must be
+#'   available variables in `data`.
+#' @param exclude_groups Character. Character specifying any values from
 #'   `category` that should not be included in the analysis. This is useful to
 #'   remove benchmarks that are not meant to be compared at the same level.
 #'   Defaults to `"benchmark"`.
@@ -26,10 +24,10 @@ prep_scatter_alignment_exposure <- function(data,
                                             region,
                                             scenario,
                                             category,
-                                            exclude_group_ids = "benchmark") {
+                                            exclude_groups = "benchmark") {
   data <- data %>%
     dplyr::filter(
-      !grepl(paste0(.env$exclude_group_ids, collapse = "|"), .data$group_id)
+      !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(category))
     ) %>%
     dplyr::filter(
       .data$year == .env$year,

--- a/R/prep_scatter_alignment_exposure.R
+++ b/R/prep_scatter_alignment_exposure.R
@@ -25,6 +25,19 @@ prep_scatter_alignment_exposure <- function(data,
                                             scenario,
                                             category,
                                             exclude_groups = "benchmark") {
+  if (!is.null(category)) {
+    if (!inherits(category, "character")) {
+      stop("category must be of class character")
+    }
+    if (!length(category) == 1) {
+      stop("category must be of length 1")
+    }
+  } else {
+    data <- data %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    category <- "aggregate_loan_book"
+  }
+
   data <- data %>%
     dplyr::filter(
       !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(category))

--- a/R/prep_scatter_alignment_exposure.R
+++ b/R/prep_scatter_alignment_exposure.R
@@ -3,14 +3,14 @@
 #' @param data data.frame. Holds net aggregated alignment metrics on the loan
 #'   book level. Must contain columns: `"scenario"`, `"region"`,
 #'   `"sector"`, `"year"`, `"exposure_weighted_net_alignment"`,
-#'   `"sum_loan_size_outstanding"` and any column implied by `category`
+#'   `"sum_loan_size_outstanding"` and any column implied by `by_group`
 #' @param year Integer. Year on which `data` should be filtered.
 #' @param region Character. Region to filter `data` data frame on.
 #' @param scenario Character. Scenario to filter `data` data frame on.
-#' @param category Character. Vector of length 1. A column to group by. Must be
+#' @param by_group Character. Vector of length 1. A column to group by. Must be
 #'   available variables in `data`.
 #' @param exclude_groups Character. Character specifying any values from
-#'   `category` that should not be included in the analysis. This is useful to
+#'   `by_group` that should not be included in the analysis. This is useful to
 #'   remove benchmarks that are not meant to be compared at the same level.
 #'   Defaults to `"benchmark"`.
 #'
@@ -23,24 +23,24 @@ prep_scatter_alignment_exposure <- function(data,
                                             year,
                                             region,
                                             scenario,
-                                            category,
+                                            by_group,
                                             exclude_groups = "benchmark") {
-  if (!is.null(category)) {
-    if (!inherits(category, "character")) {
-      stop("category must be of class character")
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
     }
-    if (!length(category) == 1) {
-      stop("category must be of length 1")
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    category <- "aggregate_loan_book"
+    by_group <- "aggregate_loan_book"
   }
 
   data <- data %>%
     dplyr::filter(
-      !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(category))
+      !grepl(paste0(.env$exclude_groups, collapse = "|"), !!rlang::sym(by_group))
     ) %>%
     dplyr::filter(
       .data$year == .env$year,
@@ -50,7 +50,7 @@ prep_scatter_alignment_exposure <- function(data,
     dplyr::select(
       dplyr::all_of(
         c(
-          .env$category,
+          by_group,
           "scenario",
           "region",
           "sector",

--- a/R/prep_scatter_animated.R
+++ b/R/prep_scatter_animated.R
@@ -35,6 +35,12 @@ prep_scatter_animated <- function(data_bopo,
     if (!length(by_group) == 1) {
       stop("by_group must be of length 1")
     }
+  } else {
+    data_bopo <- data_bopo %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    data_net <- data_net %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
   }
 
   if (data_level == "bank") {

--- a/R/prep_scatter_animated.R
+++ b/R/prep_scatter_animated.R
@@ -1,9 +1,9 @@
 #' Prepare data to plot animated scatterplot
 #'
 #' @param data_bopo data.frame. Data containing buildout and phaseout alignment
-#'   values. Must contain columns: `by_group`, `'year'`, `'sector'`, `'region'`,
+#'   values. Must contain columns: `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
-#'   `'exposure_weighted_net_alignment'`.
+#'   `'exposure_weighted_net_alignment'` plus any column implied by `by_group`.
 #' @param data_net data.frame. Data containing net alignment values. Must
 #'   contain columns: `by_group`, `'year'`, `'sector'`, `'region'`, `'direction'` and
 #'   either `'name_abcd'` and `'alignment_metric'` or `'exposure_weighted_net_alignment'`.

--- a/R/prep_scatter_animated.R
+++ b/R/prep_scatter_animated.R
@@ -7,7 +7,7 @@
 #' @param data_net data.frame. Data containing net alignment values. Must
 #'   contain columns: `group_var`, `'year'`, `'sector'`, `'region'`, `'direction'` and
 #'   either `'name_abcd'` and `'alignment_metric'` or `'exposure_weighted_net_alignment'`.
-#' @param data_level Character. Level of the plotted data. Can be `'bank'` or
+#' @param data_level Character. Level of the plotted data. Can be `'group_var'` or
 #'   `'company'`.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
@@ -21,7 +21,7 @@
 #' # TODO
 prep_scatter_animated <- function(data_bopo,
                                   data_net,
-                                  data_level = c("bank", "company"),
+                                  data_level = c("group_var", "company"),
                                   sector,
                                   region,
                                   group_var,
@@ -43,7 +43,7 @@ prep_scatter_animated <- function(data_bopo,
     group_var <- "aggregate_loan_book"
   }
 
-  if (data_level == "bank") {
+  if (data_level == "group_var") {
     name_col <- group_var
     value_col <- "exposure_weighted_net_alignment"
   } else {
@@ -76,13 +76,13 @@ prep_scatter_animated <- function(data_bopo,
     dplyr::mutate(
       datapoint = dplyr::case_when(
         grepl(".*[Bb]enchmark,*", .data$name) ~ "Benchmark",
-        TRUE & data_level == "bank" ~ "Bank",
+        TRUE & data_level == "group_var" ~ "Group",
         TRUE & data_level == "company" ~ "Company",
         TRUE ~ "Portfolio"
       )
     ) %>%
     dplyr::mutate(
-      datapoint = factor(.data$datapoint, levels = c("Bank", "Company", "Portfolio", "Benchmark"))
+      datapoint = factor(.data$datapoint, levels = c("Group", "Company", "Portfolio", "Benchmark"))
     ) %>%
     dplyr::arrange(.data$datapoint)
 

--- a/R/prep_scatter_animated.R
+++ b/R/prep_scatter_animated.R
@@ -3,15 +3,15 @@
 #' @param data_bopo data.frame. Data containing buildout and phaseout alignment
 #'   values. Must contain columns: `'year'`, `'sector'`, `'region'`,
 #'   `'direction'` and either `'name_abcd'` and `'alignment_metric'` or
-#'   `'exposure_weighted_net_alignment'` plus any column implied by `by_group`.
+#'   `'exposure_weighted_net_alignment'` plus any column implied by `group_var`.
 #' @param data_net data.frame. Data containing net alignment values. Must
-#'   contain columns: `by_group`, `'year'`, `'sector'`, `'region'`, `'direction'` and
+#'   contain columns: `group_var`, `'year'`, `'sector'`, `'region'`, `'direction'` and
 #'   either `'name_abcd'` and `'alignment_metric'` or `'exposure_weighted_net_alignment'`.
 #' @param data_level Character. Level of the plotted data. Can be `'bank'` or
 #'   `'company'`.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
-#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param group_var Character. Vector of length 1. Variable to group by.
 #' @param groups_to_plot Character vector. Groups to filter on.
 #'
 #' @return data.frame
@@ -24,41 +24,41 @@ prep_scatter_animated <- function(data_bopo,
                                   data_level = c("bank", "company"),
                                   sector,
                                   region,
-                                  by_group,
+                                  group_var,
                                   groups_to_plot = NULL) {
   rlang::arg_match(data_level)
 
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data_bopo <- data_bopo %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
     data_net <- data_net %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
   if (data_level == "bank") {
-    name_col <- by_group
+    name_col <- group_var
     value_col <- "exposure_weighted_net_alignment"
   } else {
     name_col <- "name_abcd"
     value_col <- "alignment_metric"
   }
 
-  check_prep_scatter_animated(data_bopo, sector, region, by_group, groups_to_plot, name_col, value_col)
-  check_prep_scatter_animated(data_net, sector, region, by_group, groups_to_plot, name_col, value_col)
+  check_prep_scatter_animated(data_bopo, sector, region, group_var, groups_to_plot, name_col, value_col)
+  check_prep_scatter_animated(data_net, sector, region, group_var, groups_to_plot, name_col, value_col)
 
   if (is.null(groups_to_plot)) {
     groups_to_plot <- unique(
       c(
-        dplyr::pull(data_bopo, by_group),
-        dplyr::pull(data_net, by_group)
+        dplyr::pull(data_bopo, group_var),
+        dplyr::pull(data_net, group_var)
       )
     )
   }
@@ -68,7 +68,7 @@ prep_scatter_animated <- function(data_bopo,
     dplyr::filter(
       .data$sector == .env$sector,
       .data$region == .env$region,
-      !!rlang::sym(by_group) %in% groups_to_plot
+      !!rlang::sym(group_var) %in% groups_to_plot
     ) %>%
     dplyr::select("name" = name_col, "direction", "year", "value" = value_col) %>%
     dplyr::distinct() %>%
@@ -92,14 +92,14 @@ prep_scatter_animated <- function(data_bopo,
 check_prep_scatter_animated <- function(data,
                                         sector,
                                         region,
-                                        by_group,
+                                        group_var,
                                         groups_to_plot,
                                         name_col,
                                         value_col) {
   abort_if_missing_names(
     data,
     c(
-      by_group,
+      group_var,
       "year",
       "sector",
       "region",
@@ -110,5 +110,5 @@ check_prep_scatter_animated <- function(data,
   )
   abort_if_unknown_values(sector, data, "sector")
   abort_if_unknown_values(region, data, "region")
-  abort_if_unknown_values(groups_to_plot, data, by_group)
+  abort_if_unknown_values(groups_to_plot, data, group_var)
 }

--- a/R/prep_scatter_animated.R
+++ b/R/prep_scatter_animated.R
@@ -12,7 +12,7 @@
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
 #' @param by_group Character. Vector of length 1. Variable to group by.
-#' @param groups_to_plot Character vector. Group ids to filter on.
+#' @param groups_to_plot Character vector. Groups to filter on.
 #'
 #' @return data.frame
 #' @export

--- a/R/prep_timeline.R
+++ b/R/prep_timeline.R
@@ -2,10 +2,10 @@
 #'
 #' @param data data.frame. Must contain columns: `'direction'`, `'year'`,
 #'   `'exposure_weighted_net_alignment'`, `'sector'` and any column implied by
-#'   `by_group`.
+#'   `group_var`.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
-#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param group_var Character. Vector of length 1. Variable to group by.
 #' @param groups_to_plot Character vector. Groups to filter on.
 #'
 #' @return data.frame
@@ -16,42 +16,42 @@
 prep_timeline <- function(data,
                           sector,
                           region,
-                          by_group,
+                          group_var,
                           groups_to_plot) {
-  if (!is.null(by_group)) {
-    if (!inherits(by_group, "character")) {
-      stop("by_group must be of class character")
+  if (!is.null(group_var)) {
+    if (!inherits(group_var, "character")) {
+      stop("group_var must be of class character")
     }
-    if (!length(by_group) == 1) {
-      stop("by_group must be of length 1")
+    if (!length(group_var) == 1) {
+      stop("group_var must be of length 1")
     }
   } else {
     data <- data %>%
       dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
-    by_group <- "aggregate_loan_book"
+    group_var <- "aggregate_loan_book"
   }
 
-  check_prep_timeline(data, sector, region, by_group, groups_to_plot)
+  check_prep_timeline(data, sector, region, group_var, groups_to_plot)
 
   data_timeline <- data %>%
     dplyr::filter(
       .data$sector == .env$sector,
       .data$region == .env$region,
-      !!rlang::sym(by_group) %in% groups_to_plot
+      !!rlang::sym(group_var) %in% groups_to_plot
     )
 
   data_timeline
 }
 
-check_prep_timeline <- function(data, sector, region, by_group, groups_to_plot) {
+check_prep_timeline <- function(data, sector, region, group_var, groups_to_plot) {
   abort_if_missing_names(data, c(
     "direction",
     "year",
     "exposure_weighted_net_alignment",
     "sector",
-    by_group
+    group_var
   ))
   abort_if_unknown_values(sector, data, "sector")
   abort_if_unknown_values(region, data, "region")
-  abort_if_unknown_values(groups_to_plot, data, by_group)
+  abort_if_unknown_values(groups_to_plot, data, group_var)
 }

--- a/R/prep_timeline.R
+++ b/R/prep_timeline.R
@@ -5,7 +5,7 @@
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
 #' @param by_group Character. Vector of length 1. Variable to group by.
-#' @param groups_to_plot Character vector. Group ids to filter on.
+#' @param groups_to_plot Character vector. Groups to filter on.
 #'
 #' @return data.frame
 #' @export

--- a/R/prep_timeline.R
+++ b/R/prep_timeline.R
@@ -12,7 +12,24 @@
 #'
 #' @examples
 #' # TODO
-prep_timeline <- function(data, sector, region, by_group, groups_to_plot) {
+prep_timeline <- function(data,
+                          sector,
+                          region,
+                          by_group,
+                          groups_to_plot) {
+  if (!is.null(by_group)) {
+    if (!inherits(by_group, "character")) {
+      stop("by_group must be of class character")
+    }
+    if (!length(by_group) == 1) {
+      stop("by_group must be of length 1")
+    }
+  } else {
+    data <- data %>%
+      dplyr::mutate(aggregate_loan_book = "Aggregate loan book")
+    by_group <- "aggregate_loan_book"
+  }
+
   check_prep_timeline(data, sector, region, by_group, groups_to_plot)
 
   data_timeline <- data %>%

--- a/R/prep_timeline.R
+++ b/R/prep_timeline.R
@@ -1,7 +1,8 @@
 #' Prepare data to plot timeline
 #'
-#' @param data data.frame. Must contain columns: `by_group`, `'direction'`,
-#'   `'year'`, `'exposure_weighted_net_alignment'`, `'sector'`.
+#' @param data data.frame. Must contain columns: `'direction'`, `'year'`,
+#'   `'exposure_weighted_net_alignment'`, `'sector'` and any column implied by
+#'   `by_group`.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
 #' @param by_group Character. Vector of length 1. Variable to group by.

--- a/R/prep_timeline.R
+++ b/R/prep_timeline.R
@@ -1,35 +1,39 @@
 #' Prepare data to plot timeline
 #'
-#' @param data data.frame. Must contain columns: 'direction', 'year',
-#'   'exposure_weighted_net_alignment', 'group_id', 'sector'.
+#' @param data data.frame. Must contain columns: `by_group`, `'direction'`,
+#'   `'year'`, `'exposure_weighted_net_alignment'`, `'sector'`.
 #' @param sector Character. Sector to filter data on.
 #' @param region Character. Region to filter data on.
-#' @param group_ids_to_plot Character vector. Group ids to filter on.
+#' @param by_group Character. Vector of length 1. Variable to group by.
+#' @param groups_to_plot Character vector. Group ids to filter on.
 #'
 #' @return data.frame
 #' @export
 #'
 #' @examples
 #' # TODO
-prep_timeline <- function(data, sector, region, group_ids_to_plot) {
-  check_prep_timeline(data, sector, region, group_ids_to_plot)
+prep_timeline <- function(data, sector, region, by_group, groups_to_plot) {
+  check_prep_timeline(data, sector, region, by_group, groups_to_plot)
 
   data_timeline <- data %>%
     dplyr::filter(
       .data$sector == .env$sector,
       .data$region == .env$region,
-      .data$group_id %in% group_ids_to_plot
+      !!rlang::sym(by_group) %in% groups_to_plot
     )
 
   data_timeline
 }
 
-check_prep_timeline <- function(data, sector, region, group_ids_to_plot) {
+check_prep_timeline <- function(data, sector, region, by_group, groups_to_plot) {
   abort_if_missing_names(data, c(
-    "direction", "year",
-    "exposure_weighted_net_alignment", "group_id", "sector"
+    "direction",
+    "year",
+    "exposure_weighted_net_alignment",
+    "sector",
+    by_group
   ))
   abort_if_unknown_values(sector, data, "sector")
   abort_if_unknown_values(region, data, "region")
-  abort_if_unknown_values(group_ids_to_plot, data, "group_id")
+  abort_if_unknown_values(groups_to_plot, data, by_group)
 }

--- a/man/plot_sankey.Rd
+++ b/man/plot_sankey.Rd
@@ -6,6 +6,7 @@
 \usage{
 plot_sankey(
   data,
+  by_group,
   capitalise_node_labels = TRUE,
   save_png_to = NULL,
   png_name = "sankey.png",
@@ -15,6 +16,8 @@ plot_sankey(
 \arguments{
 \item{data}{data.frame. Should have the same format as output of
 \code{prep_sankey()}}
+
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
 
 \item{capitalise_node_labels}{Logical. Flag indicating if node labels should
 be converted into better looking capitalised form.}

--- a/man/plot_sankey.Rd
+++ b/man/plot_sankey.Rd
@@ -15,7 +15,9 @@ plot_sankey(
 }
 \arguments{
 \item{data}{data.frame. Should have the same format as output of
-\code{prep_sankey()}}
+\code{prep_sankey()} and contain columns: \code{"middle_node"}, optionally
+\code{"middle_node2"}, \code{"is_aligned"}, \code{"loan_size_outstanding"}, and any column
+implied by \code{by_group}.}
 
 \item{by_group}{Character. Vector of length 1. Variable to group by.}
 

--- a/man/plot_sankey.Rd
+++ b/man/plot_sankey.Rd
@@ -6,7 +6,7 @@
 \usage{
 plot_sankey(
   data,
-  by_group,
+  group_var,
   capitalise_node_labels = TRUE,
   save_png_to = NULL,
   png_name = "sankey.png",
@@ -17,9 +17,9 @@ plot_sankey(
 \item{data}{data.frame. Should have the same format as output of
 \code{prep_sankey()} and contain columns: \code{"middle_node"}, optionally
 \code{"middle_node2"}, \code{"is_aligned"}, \code{"loan_size_outstanding"}, and any column
-implied by \code{by_group}.}
+implied by \code{group_var}.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{capitalise_node_labels}{Logical. Flag indicating if node labels should
 be converted into better looking capitalised form.}

--- a/man/plot_scatter.Rd
+++ b/man/plot_scatter.Rd
@@ -14,7 +14,7 @@ plot_scatter(
   title = NULL,
   subtitle = NULL,
   alignment_limit = NULL,
-  data_level = c("company", "bank"),
+  data_level = c("company", "group_var"),
   cap_outliers = NULL,
   floor_outliers = NULL
 )
@@ -42,7 +42,7 @@ caption.}
 scales and to alignment values for colouring. By default the maximum
 absolute alignment value of is used.}
 
-\item{data_level}{Character. Level of the plotted data. Can be 'bank' or
+\item{data_level}{Character. Level of the plotted data. Can be 'group_var' or
 'company'.}
 
 \item{cap_outliers}{Numeric. Cap which should be applied to the alignment

--- a/man/plot_scatter_alignment_exposure.Rd
+++ b/man/plot_scatter_alignment_exposure.Rd
@@ -8,7 +8,7 @@ plot_scatter_alignment_exposure(
   data,
   floor_outliers,
   cap_outliers,
-  category,
+  by_group,
   currency
 )
 }
@@ -24,7 +24,7 @@ the plot.}
 values in the data. Values bigger than cap are plotted on the border of the
 plot.}
 
-\item{category}{Character. Character specifying the variable that contains
+\item{by_group}{Character. Character specifying the variable that contains
 the groups by which to analyse the loan books.}
 
 \item{currency}{Character. Currency to display in the plot labels.}

--- a/man/plot_scatter_alignment_exposure.Rd
+++ b/man/plot_scatter_alignment_exposure.Rd
@@ -25,9 +25,7 @@ values in the data. Values bigger than cap are plotted on the border of the
 plot.}
 
 \item{category}{Character. Character specifying the variable that contains
-the groups by which to analyse the loan books. Usually this will be
-\code{"group_id"} unless there is a clearly specified reason to use another
-category.}
+the groups by which to analyse the loan books.}
 
 \item{currency}{Character. Currency to display in the plot labels.}
 }

--- a/man/plot_scatter_alignment_exposure.Rd
+++ b/man/plot_scatter_alignment_exposure.Rd
@@ -8,14 +8,14 @@ plot_scatter_alignment_exposure(
   data,
   floor_outliers,
   cap_outliers,
-  by_group,
+  group_var,
   currency
 )
 }
 \arguments{
 \item{data}{data.frame. Should have the same format as output of
 \code{prep_scatter()} and contain columns: \code{'name'}, \code{'buildout'}, \code{'phaseout'},
-\code{'net'}, and any column implied by \code{by_group}.}
+\code{'net'}, and any column implied by \code{group_var}.}
 
 \item{floor_outliers}{Numeric. Floor which should be applied to the alignment
 values in the data. Values smaller than floor are plotted on the border of
@@ -25,7 +25,7 @@ the plot.}
 values in the data. Values bigger than cap are plotted on the border of the
 plot.}
 
-\item{by_group}{Character. Character specifying the variable that contains
+\item{group_var}{Character. Character specifying the variable that contains
 the groups by which to analyse the loan books.}
 
 \item{currency}{Character. Currency to display in the plot labels.}

--- a/man/plot_scatter_alignment_exposure.Rd
+++ b/man/plot_scatter_alignment_exposure.Rd
@@ -14,7 +14,8 @@ plot_scatter_alignment_exposure(
 }
 \arguments{
 \item{data}{data.frame. Should have the same format as output of
-\code{prep_scatter()} and contain columns: 'name', 'buildout', phaseout', 'net'.}
+\code{prep_scatter()} and contain columns: \code{'name'}, \code{'buildout'}, \code{'phaseout'},
+\code{'net'}, and any column implied by \code{by_group}.}
 
 \item{floor_outliers}{Numeric. Floor which should be applied to the alignment
 values in the data. Values smaller than floor are plotted on the border of

--- a/man/plot_scatter_animated.Rd
+++ b/man/plot_scatter_animated.Rd
@@ -6,7 +6,7 @@
 \usage{
 plot_scatter_animated(
   data,
-  data_level = c("company", "bank"),
+  data_level = c("company", "group_var"),
   sector = NULL,
   scenario_source = NULL,
   scenario = NULL,
@@ -23,7 +23,7 @@ plot_scatter_animated(
 \code{prep_scatter_animated()} and contain columns: 'name', 'buildout',
 'phaseout', 'net' and 'year'.}
 
-\item{data_level}{Character. Level of the plotted data. Can be 'bank' or
+\item{data_level}{Character. Level of the plotted data. Can be 'group_var' or
 'company'.}
 
 \item{sector}{Character. Sector name to be used in the plot title.}

--- a/man/plot_timeline.Rd
+++ b/man/plot_timeline.Rd
@@ -18,8 +18,8 @@ plot_timeline(
 }
 \arguments{
 \item{data}{data.frame Should have the same format as output of
-\code{prep_timeline()} and contain columns: 'direction', 'year',
-'exposure_weighted_net_alignment', by_group.}
+\code{prep_timeline()} and contain columns: \code{'direction'}, \code{'year'},
+\code{'exposure_weighted_net_alignment'}, and any column implied by \code{by_group}.}
 
 \item{sector}{Character. Sector name to be used in the plot title.}
 

--- a/man/plot_timeline.Rd
+++ b/man/plot_timeline.Rd
@@ -10,6 +10,7 @@ plot_timeline(
   scenario_source = NULL,
   scenario = NULL,
   region = NULL,
+  by_group = NULL,
   title = NULL,
   subtitle = NULL,
   alignment_limits = NULL
@@ -18,7 +19,7 @@ plot_timeline(
 \arguments{
 \item{data}{data.frame Should have the same format as output of
 \code{prep_timeline()} and contain columns: 'direction', 'year',
-'exposure_weighted_net_alignment', 'group_id'.}
+'exposure_weighted_net_alignment', by_group.}
 
 \item{sector}{Character. Sector name to be used in the plot title.}
 
@@ -28,6 +29,8 @@ caption.}
 \item{scenario}{Character. Scenario name to be used in the plot caption.}
 
 \item{region}{Character. Region to be used in the plot caption.}
+
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
 
 \item{title}{Character. Custom title if different than default.}
 

--- a/man/plot_timeline.Rd
+++ b/man/plot_timeline.Rd
@@ -10,7 +10,7 @@ plot_timeline(
   scenario_source = NULL,
   scenario = NULL,
   region = NULL,
-  by_group = NULL,
+  group_var = NULL,
   title = NULL,
   subtitle = NULL,
   alignment_limits = NULL
@@ -19,7 +19,7 @@ plot_timeline(
 \arguments{
 \item{data}{data.frame Should have the same format as output of
 \code{prep_timeline()} and contain columns: \code{'direction'}, \code{'year'},
-\code{'exposure_weighted_net_alignment'}, and any column implied by \code{by_group}.}
+\code{'exposure_weighted_net_alignment'}, and any column implied by \code{group_var}.}
 
 \item{sector}{Character. Sector name to be used in the plot title.}
 
@@ -30,7 +30,7 @@ caption.}
 
 \item{region}{Character. Region to be used in the plot caption.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{title}{Character. Custom title if different than default.}
 

--- a/man/prep_sankey.Rd
+++ b/man/prep_sankey.Rd
@@ -4,16 +4,25 @@
 \alias{prep_sankey}
 \title{Prepare data to plot using \code{plot_sankey()}}
 \usage{
-prep_sankey(data_alignment, region, year, middle_node, middle_node2 = NULL)
+prep_sankey(
+  data_alignment,
+  region,
+  year,
+  by_group,
+  middle_node,
+  middle_node2 = NULL
+)
 }
 \arguments{
 \item{data_alignment}{data.frame. Holds aggregated alignment metrics per
-company for tms sectors. Must contain columns: \code{group_id}, \code{name_abcd},
+company for tms sectors. Must contain columns: \code{by_group}, \code{name_abcd},
 \code{sector}.}
 
 \item{region}{Character. Region to filter \code{data_alignment} data frame on.}
 
 \item{year}{Integer. Year on which \code{data_alignment} should be filtered.}
+
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
 
 \item{middle_node}{Character. Column specifying the middle nodes to be
 plotted in sankey plot. Must be present in \code{data_alignment}.}

--- a/man/prep_sankey.Rd
+++ b/man/prep_sankey.Rd
@@ -8,7 +8,7 @@ prep_sankey(
   data_alignment,
   region,
   year,
-  by_group,
+  group_var,
   middle_node,
   middle_node2 = NULL
 )
@@ -16,13 +16,13 @@ prep_sankey(
 \arguments{
 \item{data_alignment}{data.frame. Holds aggregated alignment metrics per
 company for tms sectors. Must contain columns: \code{"name_abcd"},
-\code{"sector"} and any column implied by \code{by_group}.}
+\code{"sector"} and any column implied by \code{group_var}.}
 
 \item{region}{Character. Region to filter \code{data_alignment} data frame on.}
 
 \item{year}{Integer. Year on which \code{data_alignment} should be filtered.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{middle_node}{Character. Column specifying the middle nodes to be
 plotted in sankey plot. Must be present in \code{data_alignment}.}

--- a/man/prep_sankey.Rd
+++ b/man/prep_sankey.Rd
@@ -4,22 +4,12 @@
 \alias{prep_sankey}
 \title{Prepare data to plot using \code{plot_sankey()}}
 \usage{
-prep_sankey(
-  data_alignment,
-  matched_loanbook,
-  region,
-  year,
-  middle_node,
-  middle_node2 = NULL
-)
+prep_sankey(data_alignment, region, year, middle_node, middle_node2 = NULL)
 }
 \arguments{
 \item{data_alignment}{data.frame. Holds aggregated alignment metrics per
 company for tms sectors. Must contain columns: \code{group_id}, \code{name_abcd},
 \code{sector}.}
-
-\item{matched_loanbook}{data.frame. Holds the matched loan books of a set of
-groups. Must include a column \code{group_id} and \code{loan_size_outstanding}.}
 
 \item{region}{Character. Region to filter \code{data_alignment} data frame on.}
 

--- a/man/prep_sankey.Rd
+++ b/man/prep_sankey.Rd
@@ -15,8 +15,8 @@ prep_sankey(
 }
 \arguments{
 \item{data_alignment}{data.frame. Holds aggregated alignment metrics per
-company for tms sectors. Must contain columns: \code{by_group}, \code{name_abcd},
-\code{sector}.}
+company for tms sectors. Must contain columns: \code{"name_abcd"},
+\code{"sector"} and any column implied by \code{by_group}.}
 
 \item{region}{Character. Region to filter \code{data_alignment} data frame on.}
 

--- a/man/prep_scatter.Rd
+++ b/man/prep_scatter.Rd
@@ -11,19 +11,20 @@ prep_scatter(
   year,
   sector,
   region,
-  group_ids_to_plot = NULL
+  by_group,
+  groups_to_plot = NULL
 )
 }
 \arguments{
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
-values. Must contain columns: 'group_id', 'year', 'sector', 'region',
-'direction' and either 'name_abcd' and 'alignment_metric' or
-'exposure_weighted_net_alignment'.}
+values. Must contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+\code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
+\code{'exposure_weighted_net_alignment'}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
-contain columns: 'group_id', 'year', 'sector', 'region', 'direction' and
-either 'name_abcd' and 'alignment_metric' or
-'exposure_weighted_net_alignment'.}
+contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+\code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
+\code{'exposure_weighted_net_alignment'}.}
 
 \item{data_level}{Character. Level of the plotted data. Can be 'bank' or
 'company'.}
@@ -34,7 +35,9 @@ either 'name_abcd' and 'alignment_metric' or
 
 \item{region}{Character. Region to filter data on.}
 
-\item{group_ids_to_plot}{Character vector. Bank ids to filter on.}
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
+
+\item{groups_to_plot}{Character vector. Bank ids to filter on.}
 }
 \value{
 data.frame

--- a/man/prep_scatter.Rd
+++ b/man/prep_scatter.Rd
@@ -7,11 +7,11 @@
 prep_scatter(
   data_bopo,
   data_net,
-  data_level = c("bank", "company"),
+  data_level = c("group_var", "company"),
   year,
   sector,
   region,
-  by_group,
+  group_var,
   groups_to_plot = NULL
 )
 }
@@ -19,14 +19,14 @@ prep_scatter(
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
 values. Must contain columns: \code{'year'}, \code{'sector'}, \code{'region'},
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
-\code{'exposure_weighted_net_alignment'} plus any column implied by \code{by_group}.}
+\code{'exposure_weighted_net_alignment'} plus any column implied by \code{group_var}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
-contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+contain columns: \code{group_var}, \code{'year'}, \code{'sector'}, \code{'region'},
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
 \code{'exposure_weighted_net_alignment'}.}
 
-\item{data_level}{Character. Level of the plotted data. Can be \code{'bank'} or
+\item{data_level}{Character. Level of the plotted data. Can be \code{'group_var'} or
 \code{'company'}.}
 
 \item{year}{Integer. Year on which the data should be filtered.}
@@ -35,7 +35,7 @@ contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'
 
 \item{region}{Character. Region to filter data on.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{groups_to_plot}{Character vector. Groups to filter on.}
 }

--- a/man/prep_scatter.Rd
+++ b/man/prep_scatter.Rd
@@ -26,8 +26,8 @@ contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
 \code{'exposure_weighted_net_alignment'}.}
 
-\item{data_level}{Character. Level of the plotted data. Can be 'bank' or
-'company'.}
+\item{data_level}{Character. Level of the plotted data. Can be \code{'bank'} or
+\code{'company'}.}
 
 \item{year}{Integer. Year on which the data should be filtered.}
 

--- a/man/prep_scatter.Rd
+++ b/man/prep_scatter.Rd
@@ -17,9 +17,9 @@ prep_scatter(
 }
 \arguments{
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
-values. Must contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+values. Must contain columns: \code{'year'}, \code{'sector'}, \code{'region'},
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
-\code{'exposure_weighted_net_alignment'}.}
+\code{'exposure_weighted_net_alignment'} plus any column implied by \code{by_group}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
 contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},

--- a/man/prep_scatter.Rd
+++ b/man/prep_scatter.Rd
@@ -37,7 +37,7 @@ contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'
 
 \item{by_group}{Character. Vector of length 1. Variable to group by.}
 
-\item{groups_to_plot}{Character vector. Bank ids to filter on.}
+\item{groups_to_plot}{Character vector. Groups to filter on.}
 }
 \value{
 data.frame

--- a/man/prep_scatter_alignment_exposure.Rd
+++ b/man/prep_scatter_alignment_exposure.Rd
@@ -9,7 +9,7 @@ prep_scatter_alignment_exposure(
   year,
   region,
   scenario,
-  by_group,
+  group_var,
   exclude_groups = "benchmark"
 )
 }
@@ -17,7 +17,7 @@ prep_scatter_alignment_exposure(
 \item{data}{data.frame. Holds net aggregated alignment metrics on the loan
 book level. Must contain columns: \code{"scenario"}, \code{"region"},
 \code{"sector"}, \code{"year"}, \code{"exposure_weighted_net_alignment"},
-\code{"sum_loan_size_outstanding"} and any column implied by \code{by_group}.}
+\code{"sum_loan_size_outstanding"} and any column implied by \code{group_var}.}
 
 \item{year}{Integer. Year on which \code{data} should be filtered.}
 
@@ -25,11 +25,11 @@ book level. Must contain columns: \code{"scenario"}, \code{"region"},
 
 \item{scenario}{Character. Scenario to filter \code{data} data frame on.}
 
-\item{by_group}{Character. Vector of length 1. A column to group by. Must be
+\item{group_var}{Character. Vector of length 1. A column to group by. Must be
 available variables in \code{data}.}
 
 \item{exclude_groups}{Character. Character specifying any values from
-\code{by_group} that should not be included in the analysis. This is useful to
+\code{group_var} that should not be included in the analysis. This is useful to
 remove benchmarks that are not meant to be compared at the same level.
 Defaults to \code{"benchmark"}.}
 }

--- a/man/prep_scatter_alignment_exposure.Rd
+++ b/man/prep_scatter_alignment_exposure.Rd
@@ -10,14 +10,14 @@ prep_scatter_alignment_exposure(
   region,
   scenario,
   category,
-  exclude_group_ids = "benchmark"
+  exclude_groups = "benchmark"
 )
 }
 \arguments{
 \item{data}{data.frame. Holds net aggregated alignment metrics on the loan
-book level. Must contain columns: \code{group_id}, \code{scenario}, \code{region},
-\code{sector}, \code{year}, \code{exposure_weighted_net_alignment},
-\code{sum_loan_size_outstanding}.}
+book level. Must contain columns: \code{"scenario"}, \code{"region"},
+\code{"sector"}, \code{"year"}, \code{"exposure_weighted_net_alignment"},
+\code{"sum_loan_size_outstanding"} and any column implied by \code{category}}
 
 \item{year}{Integer. Year on which \code{data} should be filtered.}
 
@@ -25,12 +25,10 @@ book level. Must contain columns: \code{group_id}, \code{scenario}, \code{region
 
 \item{scenario}{Character. Scenario to filter \code{data} data frame on.}
 
-\item{category}{Character. Character specifying the variable that contains
-the groups by which to analyse the loan books. Usually this will be
-\code{"group_id"} unless there is a clearly specified reason to use another
-category.}
+\item{category}{Character. Vector of length 1. A column to group by. Must be
+available variables in \code{data}.}
 
-\item{exclude_group_ids}{Character. Character specifying any values from
+\item{exclude_groups}{Character. Character specifying any values from
 \code{category} that should not be included in the analysis. This is useful to
 remove benchmarks that are not meant to be compared at the same level.
 Defaults to \code{"benchmark"}.}

--- a/man/prep_scatter_alignment_exposure.Rd
+++ b/man/prep_scatter_alignment_exposure.Rd
@@ -9,7 +9,7 @@ prep_scatter_alignment_exposure(
   year,
   region,
   scenario,
-  category,
+  by_group,
   exclude_groups = "benchmark"
 )
 }
@@ -17,7 +17,7 @@ prep_scatter_alignment_exposure(
 \item{data}{data.frame. Holds net aggregated alignment metrics on the loan
 book level. Must contain columns: \code{"scenario"}, \code{"region"},
 \code{"sector"}, \code{"year"}, \code{"exposure_weighted_net_alignment"},
-\code{"sum_loan_size_outstanding"} and any column implied by \code{category}}
+\code{"sum_loan_size_outstanding"} and any column implied by \code{by_group}}
 
 \item{year}{Integer. Year on which \code{data} should be filtered.}
 
@@ -25,11 +25,11 @@ book level. Must contain columns: \code{"scenario"}, \code{"region"},
 
 \item{scenario}{Character. Scenario to filter \code{data} data frame on.}
 
-\item{category}{Character. Vector of length 1. A column to group by. Must be
+\item{by_group}{Character. Vector of length 1. A column to group by. Must be
 available variables in \code{data}.}
 
 \item{exclude_groups}{Character. Character specifying any values from
-\code{category} that should not be included in the analysis. This is useful to
+\code{by_group} that should not be included in the analysis. This is useful to
 remove benchmarks that are not meant to be compared at the same level.
 Defaults to \code{"benchmark"}.}
 }

--- a/man/prep_scatter_alignment_exposure.Rd
+++ b/man/prep_scatter_alignment_exposure.Rd
@@ -17,7 +17,7 @@ prep_scatter_alignment_exposure(
 \item{data}{data.frame. Holds net aggregated alignment metrics on the loan
 book level. Must contain columns: \code{"scenario"}, \code{"region"},
 \code{"sector"}, \code{"year"}, \code{"exposure_weighted_net_alignment"},
-\code{"sum_loan_size_outstanding"} and any column implied by \code{by_group}}
+\code{"sum_loan_size_outstanding"} and any column implied by \code{by_group}.}
 
 \item{year}{Integer. Year on which \code{data} should be filtered.}
 

--- a/man/prep_scatter_animated.Rd
+++ b/man/prep_scatter_animated.Rd
@@ -16,9 +16,9 @@ prep_scatter_animated(
 }
 \arguments{
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
-values. Must contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+values. Must contain columns: \code{'year'}, \code{'sector'}, \code{'region'},
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
-\code{'exposure_weighted_net_alignment'}.}
+\code{'exposure_weighted_net_alignment'} plus any column implied by \code{by_group}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
 contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'}, \code{'direction'} and

--- a/man/prep_scatter_animated.Rd
+++ b/man/prep_scatter_animated.Rd
@@ -33,7 +33,7 @@ either \code{'name_abcd'} and \code{'alignment_metric'} or \code{'exposure_weigh
 
 \item{by_group}{Character. Vector of length 1. Variable to group by.}
 
-\item{groups_to_plot}{Character vector. Group ids to filter on.}
+\item{groups_to_plot}{Character vector. Groups to filter on.}
 }
 \value{
 data.frame

--- a/man/prep_scatter_animated.Rd
+++ b/man/prep_scatter_animated.Rd
@@ -10,27 +10,30 @@ prep_scatter_animated(
   data_level = c("bank", "company"),
   sector,
   region,
-  group_ids_to_plot = NULL
+  by_group,
+  groups_to_plot = NULL
 )
 }
 \arguments{
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
-values. Must contain columns: 'group_id', 'year', 'sector', 'region',
-'direction' and either 'name_abcd' and 'alignment_metric' or
-'exposure_weighted_net_alignment'.}
+values. Must contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'},
+\code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
+\code{'exposure_weighted_net_alignment'}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
-contain columns: 'group_id', 'year', 'sector', 'region', 'direction' and
-either 'name_abcd' and 'alignment_metric' or 'exposure_weighted_net_alignment'.}
+contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'}, \code{'direction'} and
+either \code{'name_abcd'} and \code{'alignment_metric'} or \code{'exposure_weighted_net_alignment'}.}
 
-\item{data_level}{Character. Level of the plotted data. Can be 'bank' or
-'company'.}
+\item{data_level}{Character. Level of the plotted data. Can be \code{'bank'} or
+\code{'company'}.}
 
 \item{sector}{Character. Sector to filter data on.}
 
 \item{region}{Character. Region to filter data on.}
 
-\item{group_ids_to_plot}{Character vector. Group ids to filter on.}
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
+
+\item{groups_to_plot}{Character vector. Group ids to filter on.}
 }
 \value{
 data.frame

--- a/man/prep_scatter_animated.Rd
+++ b/man/prep_scatter_animated.Rd
@@ -7,10 +7,10 @@
 prep_scatter_animated(
   data_bopo,
   data_net,
-  data_level = c("bank", "company"),
+  data_level = c("group_var", "company"),
   sector,
   region,
-  by_group,
+  group_var,
   groups_to_plot = NULL
 )
 }
@@ -18,20 +18,20 @@ prep_scatter_animated(
 \item{data_bopo}{data.frame. Data containing buildout and phaseout alignment
 values. Must contain columns: \code{'year'}, \code{'sector'}, \code{'region'},
 \code{'direction'} and either \code{'name_abcd'} and \code{'alignment_metric'} or
-\code{'exposure_weighted_net_alignment'} plus any column implied by \code{by_group}.}
+\code{'exposure_weighted_net_alignment'} plus any column implied by \code{group_var}.}
 
 \item{data_net}{data.frame. Data containing net alignment values. Must
-contain columns: \code{by_group}, \code{'year'}, \code{'sector'}, \code{'region'}, \code{'direction'} and
+contain columns: \code{group_var}, \code{'year'}, \code{'sector'}, \code{'region'}, \code{'direction'} and
 either \code{'name_abcd'} and \code{'alignment_metric'} or \code{'exposure_weighted_net_alignment'}.}
 
-\item{data_level}{Character. Level of the plotted data. Can be \code{'bank'} or
+\item{data_level}{Character. Level of the plotted data. Can be \code{'group_var'} or
 \code{'company'}.}
 
 \item{sector}{Character. Sector to filter data on.}
 
 \item{region}{Character. Region to filter data on.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{groups_to_plot}{Character vector. Groups to filter on.}
 }

--- a/man/prep_timeline.Rd
+++ b/man/prep_timeline.Rd
@@ -16,7 +16,7 @@ prep_timeline(data, sector, region, by_group, groups_to_plot)
 
 \item{by_group}{Character. Vector of length 1. Variable to group by.}
 
-\item{groups_to_plot}{Character vector. Group ids to filter on.}
+\item{groups_to_plot}{Character vector. Groups to filter on.}
 }
 \value{
 data.frame

--- a/man/prep_timeline.Rd
+++ b/man/prep_timeline.Rd
@@ -7,8 +7,9 @@
 prep_timeline(data, sector, region, by_group, groups_to_plot)
 }
 \arguments{
-\item{data}{data.frame. Must contain columns: \code{by_group}, \code{'direction'},
-\code{'year'}, \code{'exposure_weighted_net_alignment'}, \code{'sector'}.}
+\item{data}{data.frame. Must contain columns: \code{'direction'}, \code{'year'},
+\code{'exposure_weighted_net_alignment'}, \code{'sector'} and any column implied by
+\code{by_group}.}
 
 \item{sector}{Character. Sector to filter data on.}
 

--- a/man/prep_timeline.Rd
+++ b/man/prep_timeline.Rd
@@ -4,18 +4,18 @@
 \alias{prep_timeline}
 \title{Prepare data to plot timeline}
 \usage{
-prep_timeline(data, sector, region, by_group, groups_to_plot)
+prep_timeline(data, sector, region, group_var, groups_to_plot)
 }
 \arguments{
 \item{data}{data.frame. Must contain columns: \code{'direction'}, \code{'year'},
 \code{'exposure_weighted_net_alignment'}, \code{'sector'} and any column implied by
-\code{by_group}.}
+\code{group_var}.}
 
 \item{sector}{Character. Sector to filter data on.}
 
 \item{region}{Character. Region to filter data on.}
 
-\item{by_group}{Character. Vector of length 1. Variable to group by.}
+\item{group_var}{Character. Vector of length 1. Variable to group by.}
 
 \item{groups_to_plot}{Character vector. Groups to filter on.}
 }

--- a/man/prep_timeline.Rd
+++ b/man/prep_timeline.Rd
@@ -4,17 +4,19 @@
 \alias{prep_timeline}
 \title{Prepare data to plot timeline}
 \usage{
-prep_timeline(data, sector, region, group_ids_to_plot)
+prep_timeline(data, sector, region, by_group, groups_to_plot)
 }
 \arguments{
-\item{data}{data.frame. Must contain columns: 'direction', 'year',
-'exposure_weighted_net_alignment', 'group_id', 'sector'.}
+\item{data}{data.frame. Must contain columns: \code{by_group}, \code{'direction'},
+\code{'year'}, \code{'exposure_weighted_net_alignment'}, \code{'sector'}.}
 
 \item{sector}{Character. Sector to filter data on.}
 
 \item{region}{Character. Region to filter data on.}
 
-\item{group_ids_to_plot}{Character vector. Group ids to filter on.}
+\item{by_group}{Character. Vector of length 1. Variable to group by.}
+
+\item{groups_to_plot}{Character vector. Group ids to filter on.}
 }
 \value{
 data.frame


### PR DESCRIPTION
depends on https://github.com/RMI-PACTA/pacta.multi.loanbook.analysis/pull/34
closes #27 
closes #25 by coincidence

- adapts the `pacta.multi.loanbook.plot` package to changes made in `pacta.multi.loanbook.analysis`, which now allows aggregating results by any user defined variable
- all `prep_*()` and `plot_*()` functions gain flexibility in processing grouping variables
  - Where they previously expected a variable `"group_id"`, the variable can now be specified to any name using the `group_var` argument
  - Omitting the argument aggregates across all input loan books, allowing for a meta view
- coincidentally, the linked changes in `pacta.multi.loanbook.analysis` remove the need to use the `matched_prioritized` data set as an input to the sankey plot. this means that `pacta.multi.loanbook.plot` now solely uses data objects created with `pacta.multi.loanbook.analysis`
- aligns on using `group_var` in function signature, changing `category` to `group_var` in `prep_scatter_alignment_exposure()` and `plot_scatter_alignment_exposure()`
- references to `"bank"` in scatter plots are changed to `"group"` and `data_level` can now be `"company"` or `"group_var"`, not `"bank"`
